### PR TITLE
📖 [Docs]: Rework the GUID README into the standard module landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,27 @@
-# GUID
+# Guid
 
-A PowerShell module that extends the native capabilities for working with Globally Unique Identifiers (GUIDs).
-
-## Prerequisites
-
-This module uses the following external resources:
-- The [PSModule framework](https://github.com/PSModule) for building, testing, and publishing the module.
+Guid is a PowerShell module for working with GUID values.
 
 ## Installation
 
-To install the module from the PowerShell Gallery, run the following commands:
+Install the module from the PowerShell Gallery:
 
 ```powershell
-Install-PSResource -Name GUID
-Import-Module -Name GUID
+Install-PSResource -Name Guid
+Import-Module -Name Guid
 ```
 
-## Usage
+## Documentation
 
-Here are some typical use cases for the GUID module.
+Documentation is published at [psmodule.io/Guid](https://psmodule.io/Guid/).
 
-### Example 1: Test if a string is a GUID
-
-Check if a string is a valid GUID using:
+Use PowerShell help and command discovery for module details:
 
 ```powershell
-Test-Guid -Guid 'd85b1407-351d-4694-9392-03acc5870eb1'
-'d85b1407-351d-4694-9392-03acc5870eb1' | Test-Guid
-'d85b1407-351d-4694-9392-03acc5870eb1' | IsGuid
-```
-
-This command returns `True` if the provided string is a valid GUID; otherwise, it returns `False`.
-
-### Example 2: Find a GUID in a string
-
-Extract a GUID from a string using:
-
-```powershell
-Search-Guid -Text "The GUID is d85b1407-351d-4694-9392-03acc5870eb1"
-```
-
-This command returns the GUID found in the provided string.
-
-### Find More Examples
-
-For additional usage examples, please refer to the [examples](examples) folder. You can also list all available commands with:
-
-```powershell
-Get-Command -Module GUID
-```
-
-And view detailed help for each command (for instance, for New-GuidPlus) by running:
-
-```powershell
-Get-Help -Examples <command>
+Get-Command -Module Guid
+Get-Help <CommandName> -Examples
 ```
 
 ## Contributing
 
-Contributions are welcome—whether you're reporting an issue, suggesting improvements, or submitting new code!
-
-### For Users
-
-If you encounter any bugs, unexpected behavior, or missing functionality, please open an issue on this repository. Your feedback is valuable.
-
-### For Developers
-
-If you'd like to contribute code or enhancements, please review the [Contribution Guidelines](CONTRIBUTING.md) first. You can start by addressing
-an existing issue or proposing a new feature.
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GUID
 
-GUID is a PowerShell module for working with GUID values.
+A PowerShell module that extends the native capabilities for working with Globally Unique Identifiers (GUIDs).
+It adds convenient commands to validate whether a string is a GUID and to extract GUIDs embedded in text.
 
 ## Installation
 
@@ -11,17 +12,41 @@ Install-PSResource -Name GUID
 Import-Module -Name GUID
 ```
 
+## Usage
+
+### Example: Test if a string is a GUID
+
+Validate whether a string is a well-formed GUID. The command accepts pipeline input and returns a boolean.
+
+```powershell
+Test-Guid -String 'd85b1407-351d-4694-9392-03acc5870eb1'
+'d85b1407-351d-4694-9392-03acc5870eb1' | Test-Guid
+```
+
+```text
+True
+True
+```
+
+### Example: Find a GUID in a string
+
+Extract the GUID embedded in a longer string. The command returns the matched GUID value.
+
+```powershell
+'The ID is d85b1407-351d-4694-9392-03acc5870eb1' | Search-Guid
+```
+
+```text
+d85b1407-351d-4694-9392-03acc5870eb1
+```
+
 ## Documentation
 
-Documentation is available through PowerShell help and command discovery. You can also browse related module documentation at [psmodule.io](https://psmodule.io/).
+Documentation is published at [psmodule.io/GUID](https://psmodule.io/GUID/).
 
-Use PowerShell help and command discovery for module details:
+Discover the available commands and browse their help from the terminal:
 
 ```powershell
 Get-Command -Module GUID
-Get-Help Test-Guid -Examples
+Get-Help -Name Test-Guid -Examples
 ```
-
-## Contributing
-
-Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# Guid
+# GUID
 
-Guid is a PowerShell module for working with GUID values.
+GUID is a PowerShell module for working with GUID values.
 
 ## Installation
 
 Install the module from the PowerShell Gallery:
 
 ```powershell
-Install-PSResource -Name Guid
-Import-Module -Name Guid
+Install-PSResource -Name GUID
+Import-Module -Name GUID
 ```
 
 ## Documentation
 
-Documentation is published at [psmodule.io/Guid](https://psmodule.io/Guid/).
+Documentation is published at [psmodule.io/GUID](https://psmodule.io/GUID/).
 
 Use PowerShell help and command discovery for module details:
 
 ```powershell
-Get-Command -Module Guid
-Get-Help <CommandName> -Examples
+Get-Command -Module GUID
+Get-Help Test-Guid -Examples
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Import-Module -Name GUID
 
 ## Documentation
 
-Documentation is published at [psmodule.io/GUID](https://psmodule.io/GUID/).
+Documentation is available through PowerShell help and command discovery. You can also browse related module documentation at [psmodule.io](https://psmodule.io/).
 
 Use PowerShell help and command discovery for module details:
 


### PR DESCRIPTION
## 📖 Docs: Rework the GUID README into the standard module landing page

The README is now a concise landing page for the module.

**What you get**
- A `## Usage` showcase with real, copy-pasteable examples:
  - test whether a string is a GUID with `Test-Guid` (direct and via pipeline)
  - extract a GUID embedded in text with `Search-Guid`
- `## Installation` using `Install-PSResource`.
- `## Documentation` pointing at [psmodule.io/GUID](https://psmodule.io/GUID/) plus a real `Get-Help -Name Test-Guid -Examples` discovery snippet.

**Cleanup**
- Restored the working usage examples that the previous standardization pass had deleted.
- Removed the boilerplate `## Contributing` section (governance files are handled by a separate rollout).